### PR TITLE
更新本地网易云喵块至1.2.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -263,3 +263,4 @@ __pycache__/
 
 BililiveRecorder.WPF/BuildInfo.cs
 BililiveRecorder.WPF/Nlog.config
+*.wakatime-project

--- a/ExtendNetease_DGJModule/Apis/NeteaseMusicApis.GetSongDetail.cs
+++ b/ExtendNetease_DGJModule/Apis/NeteaseMusicApis.GetSongDetail.cs
@@ -29,19 +29,22 @@ namespace ExtendNetease_DGJModule.Apis
             SongInfo[] result = new SongInfo[songIds.Length];
             for (int i = 0; i < songIds.Length;)
             {
+                int taken = Math.Min(1000, songIds.Length - i);
                 KeyValuePair<string, string>[] payload = new KeyValuePair<string, string>[1]
                 {
-                    new KeyValuePair<string, string>("c", JsonConvert.SerializeObject(songIds.Skip(i).Take(Math.Min(1000, songIds.Length - i)).Select(p => new { id = p })))
+                    new KeyValuePair<string, string>("c", JsonConvert.SerializeObject(songIds.Skip(i).Take(taken).Select(p => new { id = p })))
                 };
                 JToken j = await client.PostAsync("https://music.163.com/api/v3/song/detail", new FormUrlEncodedContent(payload), token).GetJsonAsync(token);
                 if (j["code"].ToObject<int>() != 200)
                 {
                     throw new UnknownResponseException(j);
                 }
+                int k = i;
                 foreach (JToken songNode in j["songs"])
                 {
-                    result[i++] = SongInfo.Parse(songNode);
+                    result[k++] = SongInfo.Parse(songNode);
                 }
+                i += taken;
             }
             return result;
         }

--- a/ExtendNetease_DGJModule/Apis/NeteaseMusicApis.GetUserInfo.cs
+++ b/ExtendNetease_DGJModule/Apis/NeteaseMusicApis.GetUserInfo.cs
@@ -44,7 +44,7 @@ namespace ExtendNetease_DGJModule.Apis
         {
             JObject data = new JObject(new JProperty("csrf_token", GetCsrfToken(client)));
             CryptoHelper.WebApiEncryptedData encrypted = CryptoHelper.WebApiEncrypt(data);
-            JObject root = (JObject)await client.PostAsync($"https://music.163.com/weapi/v1/user/detail/{userId}", encrypted.GetContent(), token).GetJsonAsync(token).ConfigureAwait(false);
+            JObject root = (JObject)await client.PostAsync($"https://music.163.com/api/v1/user/detail/{userId}", encrypted.GetContent(), token).GetJsonAsync(token).ConfigureAwait(false);
             if (root["code"].ToObject<int>() == 200)
             {
                 return new UserInfo()

--- a/ExtendNetease_DGJModule/Apis/NeteaseMusicApis.Search.cs
+++ b/ExtendNetease_DGJModule/Apis/NeteaseMusicApis.Search.cs
@@ -29,7 +29,8 @@ namespace ExtendNetease_DGJModule.Apis
                 ["offset"] = offset
             };
             CryptoHelper.WebApiEncryptedData encrypted = CryptoHelper.WebApiEncrypt(data);
-            return client.PostAsync("https://music.163.com/weapi/cloudsearch/get/web", encrypted.GetContent(), token).GetJsonAsync(token);
+            // return client.PostAsync("https://music.163.com/weapi/cloudsearch/get/web", encrypted.GetContent(), token).GetJsonAsync(token);
+            return client.PostAsync("https://music.163.com/weapi/search/get", encrypted.GetContent(), token).GetJsonAsync(token);
         }
     }
 }

--- a/ExtendNetease_DGJModule/Apis/NeteaseMusicApis.SearchSongs.cs
+++ b/ExtendNetease_DGJModule/Apis/NeteaseMusicApis.SearchSongs.cs
@@ -1,6 +1,7 @@
 ﻿using ExtendNetease_DGJModule.Exceptions;
 using ExtendNetease_DGJModule.Models;
 using Newtonsoft.Json.Linq;
+using System;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -21,7 +22,12 @@ namespace ExtendNetease_DGJModule.Apis
             JObject root = (JObject)await SearchAsync(client, keywords, SearchType.Song, pageSize, offset, token).ConfigureAwait(false);
             if (root["code"].ToObject<int>() == 200)
             {
-                return root["result"]["songs"].Select(SongInfo.Parse).ToArray();
+                var songs = root["result"]["songs"];
+                if (songs != null)
+                {
+                    return songs.Select(SongInfo.Parse).ToArray();
+                }
+                return Array.Empty<SongInfo>();
             }
             throw new UnknownResponseException(root);
         }

--- a/ExtendNetease_DGJModule/PluginMain.cs
+++ b/ExtendNetease_DGJModule/PluginMain.cs
@@ -29,7 +29,7 @@ namespace ExtendNetease_DGJModule
         public PluginMain()
         {
             this.PluginName = "本地网易云喵块";
-            this.PluginAuth = "西井丶";
+            this.PluginAuth = "西井QAQ";
             this.PluginCont = "847529602@qq.com";
             this.PluginDesc = "可以添加歌单和登录网易云喵~";
             this.PluginVer = Assembly.GetExecutingAssembly().GetName().Version.ToString(3);

--- a/ExtendNetease_DGJModule/Properties/AssemblyInfo.cs
+++ b/ExtendNetease_DGJModule/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // 可以指定所有值，也可以使用以下所示的 "*" 预置版本号和修订号
 //通过使用 "*"，如下所示:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.2.0")]
-[assembly: AssemblyFileVersion("1.2.2.0")]
+[assembly: AssemblyVersion("1.2.5.0")]
+[assembly: AssemblyFileVersion("1.2.5.0")]


### PR DESCRIPTION
确认下载歌曲时的服务器响应是否为200
更换获取用户信息接口以解决无法正确判断用户vip状态的问题。（感谢@卡米雷特 和@某只毛玉 的协助）
更换搜索歌曲接口, 以避免时不时搜索失败的问题